### PR TITLE
Add "checkout_fetch_depth" optional input to docker-image-build/action.yml

### DIFF
--- a/composite-actions/docker-image-build/action.yml
+++ b/composite-actions/docker-image-build/action.yml
@@ -14,12 +14,16 @@ inputs:
   registry_password:
     description: the password to authenticate against the registry
     required: true
+  checkout_fetch_depth:
+    description: sets "fetch-depth" in "actions/checkout"
+    default: 1
 
 runs:
   using: "composite"
   steps:
   - uses: actions/checkout@v2
     with:
+      fetch-depth: ${{ inputs.checkout_fetch_depth }}
       path: docker-image-build  
 
   - name: Set up Docker Buildx


### PR DESCRIPTION
Allow providing a custom "fetch-depth" parameter to the "actions/checkout" step.
NOTE: this is untested.